### PR TITLE
Add setup script to setup ROS & Gazebo properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,27 @@
 cvra_debra_ros
 ==============
-
 ROS metapackage with several ROS packages related to Debra.
 
-
-Usage
+Setup
 -----
-
-It is assumed you have installed ROS and configured your ROS workspace.
-Otherwise, please refer to the [ROS installation tutorial]
-(http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment),
-it is recommended to do a full install of ROS if you have enough disk space.
-
-Note: the ROS workspace setup is treated in part 4 of the tutorial.
-
-### Initial setup
-
-Run the following commands in a terminal:
-```sh
+It is assumed you have not installed ROS and configured your ROS workspace yet.
+To setup ROS and everything, simply run:
+```bash
 bash
+mkdir -p ~/catkin_ws/src
 cd ~/catkin_ws/src
 git clone https://github.com/cvra/cvra_debra_ros.git
+chmod +x setup.bash
+sudo ./setup.bash
 cd ..
 catkin_make
 source devel/setup.bash
 ```
 
-`catkin_make` will build the package for you and the `source devel/setup.bash`
-command ensures ROS commands detect newly installed packages.
-
-Note: we assume your ROS workspace is named `catkin_ws` and is located in the
-`home` directory.
-
+Remember to run these last two lines everything you tweak or change something in the package as they will build the package and ensure ROS commands detect newly installed packages.
 
 Packages
 --------
-
 Here is a list of the packages contained in this repository:
 * **debra_control**: which handles the joint controllers
 * **debra_description**: which provides description files ot model Debra
@@ -44,7 +30,6 @@ Here is a list of the packages contained in this repository:
 
 To do
 -----
-
 * Fix the `catkin_make` compilation problem with **debra_control**. Note: this
 doesn't affect the operation of the package.
 * Fix the operation problems of running roscore in parallel with the packages

--- a/setup.bash
+++ b/setup.bash
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Install ROS
+echo "Installing ROS..."
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
+wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install -y ros-indigo-desktop-full
+
+# Setup ROS
+echo "Setting up ROS..."
+sudo rosdep init
+rosdep update
+echo "source /opt/ros/indigo/setup.bash" >> ~/.bashrc
+source ~/.bashrc
+sudo apt-get install -y python-rosinstall
+
+# Create ROS Workspace
+echo "Setting up a catkin workspace..."
+mkdir -p ~/catkin_ws/src
+cd ~/catkin_ws/src
+catkin_init_workspace
+cd ~/catkin_ws/
+catkin_make
+source devel/setup.bash
+
+# Install missing ROS packages
+echo "Installing some missing ROS packages..."
+sudo apt-get install -y ros-indigo-ros-control ros-indigo-ros-controllers ros-indigo-joystick-drivers
+
+# Install Gazebo
+echo "Installing and setting up Gazebo..."
+sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list'
+wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install -y ros-indigo-gazebo-ros-pkgs ros-indigo-gazebo-ros-control gazebo2 libsdformat1 ros-indigo-gazebo-plugins ros-indigo-gazebo-ros
+
+# Setup ROS dependencies
+echo "Setting up ROS dependencies..."
+rosdep install robot_state_publisher urdf xacro controller_manager geometry_msgs joy ros_control ros_controllers sensor_msgs std_msgs gazebo_msgs gazebo_plugins gazebo_ros gazebo_ros_control joy
+
+echo "Finishing..."


### PR DESCRIPTION
The bash script handles ROS installation and setup, then it install Gazebo and other dependencies to use the package.
Solves issue #4 
